### PR TITLE
Refactor log record offset type to uint64; implement segment management with append and read functionality; add tests for segment operations

### DIFF
--- a/workbench/api/v1/log.pb.go
+++ b/workbench/api/v1/log.pb.go
@@ -24,7 +24,7 @@ const (
 type Record struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Value         []byte                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
-	Offset        int64                  `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	Offset        uint64                 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -66,7 +66,7 @@ func (x *Record) GetValue() []byte {
 	return nil
 }
 
-func (x *Record) GetOffset() int64 {
+func (x *Record) GetOffset() uint64 {
 	if x != nil {
 		return x.Offset
 	}
@@ -80,7 +80,7 @@ const file_api_v1_log_proto_rawDesc = "" +
 	"\x10api/v1/log.proto\x12\x06log.v1\"6\n" +
 	"\x06Record\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\fR\x05value\x12\x16\n" +
-	"\x06offset\x18\x02 \x01(\x03R\x06offsetB(Z&github.com/haru-256/proglog/api/log_v1b\x06proto3"
+	"\x06offset\x18\x02 \x01(\x04R\x06offsetB(Z&github.com/haru-256/proglog/api/log_v1b\x06proto3"
 
 var (
 	file_api_v1_log_proto_rawDescOnce sync.Once

--- a/workbench/api/v1/log.proto
+++ b/workbench/api/v1/log.proto
@@ -6,5 +6,5 @@ option go_package = "github.com/haru-256/proglog/api/log_v1";
 
 message Record {
   bytes value = 1;
-  int64 offset = 2;
+  uint64 offset = 2;
 }

--- a/workbench/internal/log/index.go
+++ b/workbench/internal/log/index.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -63,7 +64,7 @@ func (i *index) Read(in int64) (out uint32, pos uint64, err error) {
 		return 0, 0, io.EOF
 	}
 	if in < -1 {
-		return 0, 0, io.EOF
+		return 0, 0, fmt.Errorf("index: invalid index %d", in)
 	}
 	var indexOff uint32 // indexOff is the offset of index
 	var indexPos uint64 // indexPos is the position in the index file

--- a/workbench/internal/log/segment.go
+++ b/workbench/internal/log/segment.go
@@ -35,7 +35,7 @@ func newSegment(dir string, baseOffset uint64, c Config) (*segment, error) {
 	}
 	indexFile, err := os.OpenFile(
 		filepath.Join(dir, fmt.Sprintf("%d%s", baseOffset, ".index")),
-		os.O_RDWR|os.O_CREATE, // why not append?
+		os.O_RDWR|os.O_CREATE, // O_APPEND is not used because the index file requires precise control over read and write offsets, which is incompatible with appending all writes to the end of the file.
 		0600,
 	)
 	if err != nil {

--- a/workbench/internal/log/segment.go
+++ b/workbench/internal/log/segment.go
@@ -1,0 +1,123 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	api "github.com/haru-256/proglog/api/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+type segment struct {
+	store                  *store
+	index                  *index
+	baseOffset, nextOffset uint64
+	config                 Config
+}
+
+func newSegment(dir string, baseOffset uint64, c Config) (*segment, error) {
+	s := &segment{
+		baseOffset: baseOffset,
+		config:     c,
+	}
+	storeFile, err := os.OpenFile(
+		filepath.Join(dir, fmt.Sprintf("%d%s", baseOffset, ".store")),
+		os.O_RDWR|os.O_CREATE|os.O_APPEND,
+		0600,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if s.store, err = newStore(storeFile); err != nil {
+		return nil, err
+	}
+	indexFile, err := os.OpenFile(
+		filepath.Join(dir, fmt.Sprintf("%d%s", baseOffset, ".index")),
+		os.O_RDWR|os.O_CREATE, // why not append?
+		0600,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if s.index, err = newIndex(indexFile, c); err != nil {
+		return nil, err
+	}
+	if off, _, err := s.index.Read(-1); err != nil {
+		if err != io.EOF {
+			return nil, fmt.Errorf("read last index entry: %w", err)
+		}
+		s.nextOffset = baseOffset
+	} else {
+		s.nextOffset = baseOffset + uint64(off) + 1
+	}
+	return s, nil
+}
+
+// Append appends a record to the segment.
+// It returns the absolute offset of the record in the log and an error if any.
+func (s *segment) Append(record *api.Record) (offset uint64, err error) {
+	cur := s.nextOffset
+	record.Offset = cur
+	p, err := proto.Marshal(record)
+	if err != nil {
+		return 0, fmt.Errorf("marshal record: %w", err)
+	}
+	_, pos, err := s.store.Append(p)
+	if err != nil {
+		return 0, fmt.Errorf("append record: %w", err)
+	}
+
+	// index offset is the relative offset from the base offset of the segment
+	if err := s.index.Write(uint32(record.Offset-s.baseOffset), pos); err != nil {
+		return 0, fmt.Errorf("write index: %w", err)
+	}
+	s.nextOffset++ // increment nextOffset for the next record
+	return cur, nil
+}
+
+// Read reads a record at the given offset from the segment.
+// off is the absolute offset in the log, not relative to the segment.
+func (s *segment) Read(off uint64) (*api.Record, error) {
+	_, pos, err := s.index.Read(int64(off - s.baseOffset))
+	if err != nil {
+		return nil, fmt.Errorf("read index: %w", err)
+	}
+	p, err := s.store.Read(pos)
+	if err != nil {
+		return nil, fmt.Errorf("read store: %w", err)
+	}
+	record := &api.Record{}
+	err = proto.Unmarshal(p, record)
+	return record, err
+}
+
+func (s *segment) IsMaxed() bool {
+	return s.store.size >= s.config.Segment.MaxStoreBytes ||
+		s.index.size >= s.config.Segment.MaxIndexBytes ||
+		s.index.isMaxed()
+}
+
+func (s *segment) Remove() error {
+	if err := s.Close(); err != nil {
+		return fmt.Errorf("close store: %w", err)
+	}
+	if err := os.Remove(s.store.Name()); err != nil {
+		return fmt.Errorf("remove store file: %w", err)
+	}
+	if err := os.Remove(s.index.Name()); err != nil {
+		return fmt.Errorf("remove index file: %w", err)
+	}
+	return nil
+}
+
+func (s *segment) Close() error {
+	if err := s.store.Close(); err != nil {
+		return fmt.Errorf("close store: %w", err)
+	}
+	if err := s.index.Close(); err != nil {
+		return fmt.Errorf("close index: %w", err)
+	}
+	return nil
+}

--- a/workbench/internal/log/segment_test.go
+++ b/workbench/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment_test")
+	dir, err := os.MkdirTemp("", "segment_test")
+	require.NoError(t, err, "expected no error when creating temporary directory")
 	t.Cleanup(func() {
 		os.RemoveAll(dir)
 	})

--- a/workbench/internal/log/segment_test.go
+++ b/workbench/internal/log/segment_test.go
@@ -1,0 +1,62 @@
+package log
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	api "github.com/haru-256/proglog/api/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSegment(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "segment_test")
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
+
+	want := &api.Record{Value: []byte("hello world")}
+
+	c := Config{}
+	c.Segment.MaxStoreBytes = 1024
+	c.Segment.MaxIndexBytes = entWidth * 3
+	baseOffset := uint64(16)
+
+	s, err := newSegment(dir, baseOffset, c)
+	require.NoError(t, err)
+	require.Equal(t, baseOffset, s.nextOffset, "expected next offset to be 16")
+	require.False(t, s.IsMaxed(), "expected segment to not be maxed")
+
+	for i := uint64(0); i < 3; i++ {
+		off, err := s.Append(want)
+		require.NoError(t, err, "expected no error when appending record")
+		require.Equal(t, baseOffset+i, off, "expected offset to match next offset")
+
+		got, err := s.Read(off)
+		require.NoError(t, err, "expected no error when reading record")
+		require.Equal(t, want.Value, got.Value, "expected record value to match")
+	}
+
+	_, err = s.Append(want)
+	require.ErrorIs(t, err, io.EOF, "expected io.EOF error when appending to maxed segment")
+
+	require.True(t, s.IsMaxed(), "expected segment to be maxed")
+	require.NoError(t, s.Close(), "expected no error when closing segment")
+
+	p, _ := proto.Marshal(want)
+	c.Segment.MaxStoreBytes = uint64(len(p)+lenWidth) * 4 // (byte length + record length) x 4
+	c.Segment.MaxIndexBytes = 1024
+	// Recreate the segment with a new config
+	s, err = newSegment(dir, baseOffset, c)
+	require.NoError(t, err, "expected no error when creating new segment")
+	// Check if the segment is maxed
+	require.True(t, s.IsMaxed(), "expected segment to be maxed after recreation")
+
+	require.NoError(t, s.Remove(), "expected no error when removing segment")
+
+	s, err = newSegment(dir, baseOffset, c)
+	require.NoError(t, err, "expected no error when creating new segment after removal")
+	require.False(t, s.IsMaxed(), "expected segment to not be maxed after removal")
+	require.NoError(t, s.Close(), "expected no error when closing segment after removal")
+}

--- a/workbench/internal/log/store.go
+++ b/workbench/internal/log/store.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	lenWidth = 8
+	lenWidth = 8 // lenWidth is the number of bytes used to store the length of each record.
 )
 
 type store struct {


### PR DESCRIPTION
This pull request introduces several changes to the `workbench` package, focusing on improving type safety, error handling, and functionality for managing log segments. The most significant updates include changing the `offset` field type in the protobuf definition and generated code, enhancing error handling in the `index` implementation, adding a new `segment` abstraction, and implementing comprehensive tests for the `segment` functionality.

### Type Safety Improvements:
* Changed the `offset` field in `protobuf` definitions and generated code (`workbench/api/v1/log.proto`, `workbench/api/v1/log.pb.go`) from `int64` to `uint64` to ensure offsets cannot be negative. [[1]](diffhunk://#diff-4c923cb42ea8d93dc6eaf80121aed4fa5215ad8f0006c310a85d470fd214d5abL9-R9) [[2]](diffhunk://#diff-a6004da12f5f7ce579e8e9925a9c30590f6fe0270b455db9672dac4e88cf4aebL27-R27) [[3]](diffhunk://#diff-a6004da12f5f7ce579e8e9925a9c30590f6fe0270b455db9672dac4e88cf4aebL69-R69) [[4]](diffhunk://#diff-a6004da12f5f7ce579e8e9925a9c30590f6fe0270b455db9672dac4e88cf4aebL83-R83)

### Error Handling Enhancements:
* Updated the `index` implementation to return a descriptive error message when an invalid index is provided (`workbench/internal/log/index.go`).

### New Segment Abstraction:
* Introduced the `segment` type in `workbench/internal/log/segment.go`, encapsulating logic for appending, reading, and managing log records and their associated index. This includes methods like `Append`, `Read`, `IsMaxed`, `Remove`, and `Close`.

### Testing for Segment Functionality:
* Added comprehensive tests for the `segment` implementation in `workbench/internal/log/segment_test.go`. These tests validate segment creation, record appending and reading, segment maxing behavior, and removal functionality.

### Minor Documentation Update:
* Added a clarifying comment for the `lenWidth` constant in `workbench/internal/log/store.go`.