### PR TITLE
feat: Enhance Membership management with detailed comments and add tests for cluster behavior

### DIFF
--- a/workbench/.vscode/settings.json
+++ b/workbench/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["casbin", "gencert", "Memberlist"]
+  "cSpell.words": ["casbin", "dynaport", "gencert", "Memberlist"]
 }

--- a/workbench/go.mod
+++ b/workbench/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/serf v0.10.2
 	github.com/stretchr/testify v1.10.0
+	github.com/travisjeffery/go-dynaport v1.0.0
 	github.com/tysonmote/gommap v0.0.3
 	go.opencensus.io v0.24.0
 	go.uber.org/zap v1.27.0

--- a/workbench/go.sum
+++ b/workbench/go.sum
@@ -183,6 +183,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/travisjeffery/go-dynaport v1.0.0 h1:m/qqf5AHgB96CMMSworIPyo1i7NZueRsnwdzdCJ8Ajw=
+github.com/travisjeffery/go-dynaport v1.0.0/go.mod h1:0LHuDS4QAx+mAc4ri3WkQdavgVoBIZ7cE9ob17KIAJk=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tysonmote/gommap v0.0.3 h1:/TgH30oyoBKMHQu+RsbDVjgHxA6R/aARv055Z36Li88=
 github.com/tysonmote/gommap v0.0.3/go.mod h1:XsS5iBGqoNFLB6QPtF8ZKx7SHFi3Gx+QgzExGyXJ9MA=

--- a/workbench/internal/discovery/membership.go
+++ b/workbench/internal/discovery/membership.go
@@ -7,14 +7,31 @@ import (
 	"go.uber.org/zap"
 )
 
+// Membership manages cluster membership using HashiCorp Serf.
+// It provides service discovery capabilities through a gossip protocol,
+// automatically detecting when nodes join or leave the cluster.
+//
+// The Membership struct embeds configuration and maintains a Serf agent
+// that communicates with other cluster members to propagate membership changes.
+// When membership events occur, the configured Handler is called to take
+// appropriate action (e.g., updating load balancer routes).
 type Membership struct {
-	Config
-	handler Handler
-	serf    *serf.Serf
-	events  chan serf.Event
-	logger  *zap.Logger
+	Config                    // Embedded configuration for node settings
+	handler Handler           // Handler for processing membership events (join/leave)
+	serf    *serf.Serf        // Serf agent for gossip-based cluster membership
+	events  chan serf.Event   // Channel for receiving Serf membership events
+	logger  *zap.Logger       // Logger for membership-related events and errors
 }
 
+// New creates a new Membership instance for cluster discovery and management.
+// It initializes a Serf agent that uses gossip protocol to maintain cluster membership.
+//
+// Parameters:
+//   - handler: Interface for handling cluster membership events (join/leave)
+//   - config: Configuration including node name, bind address, tags, and join addresses
+//
+// Returns a configured Membership instance ready to participate in the cluster,
+// or an error if Serf initialization fails.
 func New(handler Handler, config Config) (*Membership, error) {
 	c := &Membership{
 		Config:  config,

--- a/workbench/internal/discovery/membership_test.go
+++ b/workbench/internal/discovery/membership_test.go
@@ -1,0 +1,88 @@
+package discovery_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/haru-256/proglog/internal/discovery"
+	"github.com/hashicorp/serf/serf"
+	"github.com/stretchr/testify/require"
+	"github.com/travisjeffery/go-dynaport"
+)
+
+func TestMembership(t *testing.T) {
+	m, handler := setupMember(t, nil)
+	m, _ = setupMember(t, m)
+	m, _ = setupMember(t, m)
+
+	require.Eventually(t, func() bool {
+		{
+			return len(handler.joins) == 2 &&
+				len(m[0].Members()) == 3 &&
+				len(handler.leaves) == 0
+		}
+	}, 3*time.Second, 250*time.Millisecond)
+
+	require.NoError(t, m[2].Leave())
+
+	require.Eventually(t, func() bool {
+		return len(handler.joins) == 2 &&
+			len(m[0].Members()) == 3 &&
+			m[0].Members()[2].Status == serf.StatusLeft &&
+			len(handler.leaves) == 1
+	}, 3*time.Second, 250*time.Millisecond)
+
+	require.Equal(t, "2", <-handler.leaves)
+}
+
+func setupMember(t *testing.T, members []*Membership) (
+	[]*Membership, *handler,
+) {
+	id := len(members)
+	ports := dynaport.Get(1)
+	addr := fmt.Sprintf("%s:%d", "127.0.0.1", ports[0])
+	tags := map[string]string{
+		"rpc_addr": addr,
+	}
+	c := Config{
+		NodeName: fmt.Sprintf("%d", id),
+		BindAddr: addr,
+		Tags:     tags,
+	}
+	h := &handler{}
+	if len(members) == 0 {
+		h.joins = make(chan map[string]string, 3)
+		h.leaves = make(chan string, 3)
+	} else {
+		c.StartJoinAddrs = []string{
+			members[0].BindAddr,
+		}
+	}
+	m, err := New(h, c)
+	require.NoError(t, err)
+	members = append(members, m)
+	return members, h
+}
+
+type handler struct {
+	joins  chan map[string]string
+	leaves chan string
+}
+
+func (h *handler) Join(id, addr string) error {
+	if h.joins != nil {
+		h.joins <- map[string]string{
+			"id":   id,
+			"addr": addr,
+		}
+	}
+	return nil
+}
+
+func (h *handler) Leave(id string) error {
+	if h.leaves != nil {
+		h.leaves <- id
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request introduces enhancements to the `Membership` struct and associated functionality for managing cluster membership using HashiCorp Serf. Key changes include improved documentation, the addition of a new dependency, and the creation of comprehensive tests for the `Membership` functionality.

### Enhancements to `Membership` functionality:
* Added detailed documentation to the `Membership` struct and the `New` function to describe their purpose, parameters, and behavior. This improves code readability and developer understanding. (`workbench/internal/discovery/membership.go`, [workbench/internal/discovery/membership.goR10-R34](diffhunk://#diff-bdf2857c3332a0e844dfc2e8d1932ec54e44146e7736f3ccfbafb448d929a263R10-R34))

### Dependency updates:
* Added the `github.com/travisjeffery/go-dynaport` package to `go.mod` for dynamic port allocation, which is used in the new tests. (`workbench/go.mod`, [workbench/go.modR12](diffhunk://#diff-f654d4f6943eb129bacd856eccea6e8c49bfd33f565d227226f879e08236242bR12))

### Testing improvements:
* Introduced a new test suite in `membership_test.go` to validate `Membership` functionality, including node joins, leaves, and Serf status updates. The tests use the `go-dynaport` library for dynamic port allocation and `testify` for assertions. (`workbench/internal/discovery/membership_test.go`, [workbench/internal/discovery/membership_test.goR1-R88](diffhunk://#diff-f86a67b392943b74f3222fb16e5355536968f1a671754334c79197323828d1c7R1-R88))

### Miscellaneous:
* Updated the `.vscode/settings.json` file to include "dynaport" in the spell-check dictionary to avoid false positives during development. (`workbench/.vscode/settings.json`, [workbench/.vscode/settings.jsonL2-R2](diffhunk://#diff-8693b64a2dbede2c3b34a72fd498f71ff577aab2ecf2128ca07ccdae0ea4eafcL2-R2))