### PR TITLE
feat: Add tests for agent functionality including TLS configuration and message production/consumption

### DIFF
--- a/workbench/internal/agent/agent_test.go
+++ b/workbench/internal/agent/agent_test.go
@@ -1,0 +1,123 @@
+package agent_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	api "github.com/haru-256/proglog/api/v1"
+	"github.com/haru-256/proglog/internal/agent"
+	"github.com/haru-256/proglog/internal/config"
+	"github.com/stretchr/testify/require"
+	"github.com/travisjeffery/go-dynaport"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestAgent(t *testing.T) {
+	serverTLSConfig, err := config.SetupTLSConfig(config.TLSConfig{
+		CertFile:      config.ServerCertFile,
+		KeyFile:       config.ServerKeyFile,
+		CAFile:        config.CAFile,
+		Server:        true,
+		ServerAddress: "127.0.0.1",
+	})
+	require.NoError(t, err)
+
+	peerTLSConfig, err := config.SetupTLSConfig(config.TLSConfig{
+		CertFile:      config.RootClientCertFile,
+		KeyFile:       config.RootClientKeyFile,
+		CAFile:        config.CAFile,
+		Server:        false,
+		ServerAddress: "127.0.0.1",
+	})
+	require.NoError(t, err)
+
+	var agents []*agent.Agent
+	for i := 0; i < 3; i++ {
+		ports := dynaport.Get(2)
+		bindAddr := fmt.Sprintf("%s:%d", "127.0.0.1", ports[0])
+		rpcPort := ports[1]
+
+		dataDir, err := os.MkdirTemp("", "agent-test-log")
+		require.NoError(t, err)
+
+		var startJoinAddrs []string
+		if i != 0 {
+			startJoinAddrs = append(startJoinAddrs, agents[0].Config.BindAddr)
+		}
+
+		agent, err := agent.New(agent.Config{
+			NodeName:        fmt.Sprintf("%d", i),
+			StartJoinAddrs:  startJoinAddrs,
+			BindAddr:        bindAddr,
+			RPCPort:         rpcPort,
+			DataDir:         dataDir,
+			ACLModelFile:    config.ACLModelFile,
+			ACLPolicyFile:   config.ACLPolicyFile,
+			ServerTLSConfig: serverTLSConfig,
+			PeerTlsConfig:   peerTLSConfig,
+		})
+		require.NoError(t, err)
+
+		agents = append(agents, agent)
+	}
+	t.Cleanup(func() {
+		for _, agent := range agents {
+			err := agent.Shutdown()
+			require.NoError(t, err)
+			require.NoError(t, os.RemoveAll(agent.Config.DataDir))
+		}
+	})
+	time.Sleep(3 * time.Second)
+
+	leaderClient := client(t, agents[0], peerTLSConfig)
+	produceResponse, err := leaderClient.Produce(
+		context.Background(),
+		&api.ProduceRequest{
+			Record: &api.Record{
+				Value: []byte("test message"),
+			},
+		},
+	)
+	require.NoError(t, err)
+	consumeResponse, err := leaderClient.Consume(
+		context.Background(),
+		&api.ConsumeRequest{
+			Offset: produceResponse.Offset,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, produceResponse.Offset, consumeResponse.Record.Offset)
+	require.Equal(t, []byte("test message"), consumeResponse.Record.Value)
+
+	// レプリケーションが完了するまで待つ
+	time.Sleep(3 * time.Second)
+
+	followerClient := client(t, agents[1], peerTLSConfig)
+	consumeResponse, err = followerClient.Consume(
+		context.Background(),
+		&api.ConsumeRequest{
+			Offset: produceResponse.Offset,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, produceResponse.Offset, consumeResponse.Record.Offset)
+	require.Equal(t, []byte("test message"), consumeResponse.Record.Value)
+}
+
+func client(t *testing.T, agent *agent.Agent, tlsConfig *tls.Config) api.LogClient {
+	tlsCreds := credentials.NewTLS(tlsConfig)
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(tlsCreds)}
+	rpcAddr, err := agent.Config.RPCAddr()
+	require.NoError(t, err)
+
+	conn, err := grpc.NewClient(rpcAddr, opts...)
+	require.NoError(t, err)
+
+	client := api.NewLogClient(conn)
+	return client
+}


### PR DESCRIPTION
This pull request introduces a new test case for the `Agent` component in the `workbench/internal/agent/agent_test.go` file. The test verifies the functionality of a distributed log system, including message production, consumption, and replication across multiple agents.

### New Test Case for Agent:

* **Added `TestAgent` function**: Implements a comprehensive test for the `Agent` component, setting up a cluster of three agents with TLS configuration, producing a message, consuming it from the leader, and verifying replication by consuming the same message from a follower.
* **Helper function `client`**: Introduced to simplify the creation of gRPC clients for interacting with agents in the test.